### PR TITLE
Allow to read username and password from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,13 @@ Note: the date format is as follows : 2021-12-31
 ```shell
 python -m garminworkouts -u [GARMIN_USERNAME] -p [GARMIN_PASSWORD] schedule -d [DATE] -w [WORKOUT_ID]
 ```
+
+## Username and password from environment variables
+
+Alternatively to the `-u` and `-p` arguments, it is possible to load the username and password from the `GARMIN_USERNAME` and `GARMIN_PASSWORD` environment variables:
+
+```shell
+export GARMIN_USERNAME=username
+export GARMIN_PASSWORD=password
+python -m garminworkouts list
+```

--- a/garminworkouts/__main__.py
+++ b/garminworkouts/__main__.py
@@ -9,6 +9,7 @@ from garminworkouts.config import configreader
 from garminworkouts.garmin.garminclient import GarminClient
 from garminworkouts.models.workout import Workout
 from garminworkouts.utils.validators import writeable_dir
+from garminworkouts.utils.envdefault import EnvDefault
 
 
 def command_import(args):
@@ -84,8 +85,10 @@ def _garmin_client(args):
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="Manage Garmin Connect workout(s)")
-    parser.add_argument("--username", "-u", required=True, help="Garmin Connect account username")
-    parser.add_argument("--password", "-p", required=True, help="Garmin Connect account password")
+    parser.add_argument("--username", "-u", action=EnvDefault, envvar="GARMIN_USERNAME",
+                        required=True, help="Garmin Connect account username")
+    parser.add_argument("--password", "-p", action=EnvDefault, envvar="GARMIN_PASSWORD",
+                        required=True, help="Garmin Connect account password")
     parser.add_argument("--cookie-jar", default=".garmin-cookies.txt", help="Filename with authentication cookies")
     parser.add_argument("--connect-url", default="https://connect.garmin.com", help="Garmin Connect url")
     parser.add_argument("--sso-url", default="https://sso.garmin.com", help="Garmin SSO url")

--- a/garminworkouts/utils/envdefault.py
+++ b/garminworkouts/utils/envdefault.py
@@ -1,0 +1,16 @@
+import argparse
+import os
+
+
+class EnvDefault(argparse.Action):
+    def __init__(self, envvar, required=True, default=None, **kwargs):
+        if not default and envvar:
+            if envvar in os.environ:
+                default = os.environ[envvar]
+        if required and default:
+            required = False
+        super(EnvDefault, self).__init__(default=default, required=required,
+                                         **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)


### PR DESCRIPTION
This makes it possible to read the username and password from the environment variables `GARMIN_USERNAME` and `GARMIN_PASSWORD`.

This is quite convenient so you don't have to write then in a command every time.